### PR TITLE
Fix/allowedPaymentTypes value

### DIFF
--- a/unified-checkout-node/Data/default-uc-capture-context-request.json
+++ b/unified-checkout-node/Data/default-uc-capture-context-request.json
@@ -2,7 +2,7 @@
     "targetOrigins" : [ "https://localhost:3000" ],
     "clientVersion" : "0.26",
     "allowedCardNetworks" : [ "VISA", "MASTERCARD", "AMEX", "DISCOVER", "JCB", "DINERSCLUB"],
-    "allowedPaymentTypes" : ["CLICKTOPAY", "GOOGLEPAY"],
+    "allowedPaymentTypes" : ["PANENTRY"],
     "country" : "US",
     "locale" : "en_US",
     "captureMandate" : {


### PR DESCRIPTION
fixes error which blocks user from generating capture context. There is no error message in the browser, but terminal shows the error.

<img width="1502" height="815" alt="Screenshot 2569-04-12 at 07 50 10" src="https://github.com/user-attachments/assets/6e262f3c-13a0-4080-ac5a-40f7958c2424" />

"status":400,"text":"\"{\\\"message\\\":\\\"A Validation Error Occurred.\\\",\\\"reason\\\":\\\"UNIFIEDPAYMENTS_VALIDATION_FIELDS\\\",\\\"informationLink\\\":\\\"https://developer.cybersource.com\\\",\\\"details\\\":[{\\\"location\\\":\\\"/allowedPaymentTypes\\\",\\\"message\\\":\\\"$.allowedPaymentTypes: None of the requested payment types are enabled and available\\\"}]}\""}}